### PR TITLE
Automate institution name extraction

### DIFF
--- a/informativos-builder.html
+++ b/informativos-builder.html
@@ -587,8 +587,15 @@
         // -----------------------
         // EXTRAÇÃO (PDF.js)
         // -----------------------
-        async function extractTextWithPDFjs(file, maxPages = 2) {
-            const buf = await file.arrayBuffer();
+        async function extractTextWithPDFjs(input, maxPages = 2) {
+            let buf;
+            if (input instanceof ArrayBuffer) {
+                buf = input;
+            } else if (input && typeof input.arrayBuffer === 'function') {
+                buf = await input.arrayBuffer();
+            } else {
+                throw new Error('Entrada inválida para extração de texto');
+            }
             const doc = await pdfjsLib.getDocument({ data: buf }).promise;
             let out = '';
             const pages = Math.min(doc.numPages, maxPages);
@@ -600,6 +607,116 @@
                 out += strings.join('\n') + '\n';
             }
             return out;
+        }
+
+        async function extractHeadingsFromPdf(arrayBuf, maxPages = 3) {
+            const doc = await pdfjsLib.getDocument({ data: arrayBuf }).promise;
+            const roleToTag = {
+                Document: 'div',
+                Part: 'section',
+                Sect: 'section',
+                Div: 'div',
+                P: 'p',
+                Span: 'span',
+                H1: 'h1',
+                H2: 'h2',
+                H3: 'h3',
+                H4: 'h4',
+                H5: 'h5',
+                H6: 'h6',
+                Caption: 'figcaption',
+                L: 'ul',
+                LI: 'li'
+            };
+
+            const escapeHtml = str => String(str ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+
+            const parser = new DOMParser();
+            let niceName = '';
+            let informativoNum = '';
+
+            const pages = Math.min(doc.numPages, maxPages);
+            for (let p = 1; p <= pages; p++) {
+                if (niceName && informativoNum) break;
+                const page = await doc.getPage(p);
+                let structTree;
+                try {
+                    structTree = await page.getStructTree();
+                } catch (err) {
+                    console.warn('Estrutura semântica indisponível na página', p, err);
+                    continue;
+                }
+                if (!structTree) continue;
+
+                const textContent = await page.getTextContent({ includeMarkedContent: true });
+                const mcidMap = new Map();
+                for (const item of textContent.items) {
+                    if (item && typeof item.markedContentId === 'number' && item.markedContentId >= 0) {
+                        const segments = mcidMap.get(item.markedContentId) || [];
+                        segments.push(item.str || '');
+                        mcidMap.set(item.markedContentId, segments);
+                    }
+                }
+
+                const textForId = id => {
+                    const segments = mcidMap.get(id);
+                    if (!segments || !segments.length) return '';
+                    return segments.join(' ').replace(/\s+/g, ' ').trim();
+                };
+
+                const nodeToHtml = node => {
+                    if (!node) return '';
+                    const children = Array.isArray(node.children) ? node.children : [];
+                    const inner = children.map(child => {
+                        if (!child) return '';
+                        if (child.type === 'content' && typeof child.id === 'number') {
+                            return escapeHtml(textForId(child.id));
+                        }
+                        if (child.children) {
+                            return nodeToHtml(child);
+                        }
+                        return '';
+                    }).join('');
+
+                    const tag = roleToTag[node.role] || 'div';
+                    return `<${tag}>${inner}</${tag}>`;
+                };
+
+                const html = nodeToHtml(structTree);
+                if (!html) continue;
+
+                const docHtml = parser.parseFromString(`<div>${html}</div>`, 'text/html');
+                if (!niceName) {
+                    const h1 = docHtml.querySelector('h1');
+                    if (h1 && h1.textContent) {
+                        const text = h1.textContent.replace(/\s+/g, ' ').trim();
+                        if (text) niceName = text;
+                    }
+                }
+                if (!informativoNum) {
+                    const h3 = docHtml.querySelector('h3');
+                    if (h3 && h3.textContent) {
+                        const text = h3.textContent.replace(/\s+/g, ' ').trim();
+                        const match = text.match(/N\.?º\s*(\d{1,4})/i) || text.match(/N\.?o\s*(\d{1,4})/i);
+                        if (match) {
+                            informativoNum = match[1];
+                        } else {
+                            const fallback = text.match(/\b(\d{1,4})\b/);
+                            if (fallback) informativoNum = fallback[1];
+                        }
+                    }
+                }
+            }
+
+            return {
+                niceName,
+                num: informativoNum
+            };
         }
 
         const lowerCaseWords = new Set(['de', 'da', 'do', 'das', 'dos', 'e', 'em', 'para', 'por', 'per', 'del', 'della', 'du', 'des', 'di']);
@@ -776,10 +893,27 @@
         async function handleOneFile(file) {
             if (!/\.pdf$/i.test(file.name)) return null;
 
+            const arrayBuf = await file.arrayBuffer();
             let extracted = { code: '', niceName: '', num: '' };
+
             try {
-                const fullText = await extractTextWithPDFjs(file);
-                extracted = parseInstitutionInfo(fullText);
+                const headingInfo = await extractHeadingsFromPdf(arrayBuf);
+                extracted.niceName = headingInfo.niceName || '';
+                extracted.num = headingInfo.num || '';
+            } catch (err) {
+                console.warn('Falha na extração de headings:', err);
+            }
+
+            try {
+                const fullText = await extractTextWithPDFjs(arrayBuf);
+                const parsed = parseInstitutionInfo(fullText);
+                extracted.code = parsed.code || extracted.code;
+                if (!extracted.niceName && parsed.niceName) {
+                    extracted.niceName = parsed.niceName;
+                }
+                if (!extracted.num && parsed.num) {
+                    extracted.num = parsed.num;
+                }
             } catch (e) {
                 console.warn('Falha na extração com PDF.js:', e);
             }

--- a/informativos-builder.html
+++ b/informativos-builder.html
@@ -653,26 +653,67 @@
                 return { code, niceName, num };
             }
 
-            // 3) Procura nas primeiras linhas por um nome completo
-            const headerCandidates = [];
-            for (let i = 0; i < headerBlock.length; i++) {
-                let line = headerBlock[i];
-                if (/^INFORMATIVO/i.test(line)) continue;
-                if (!keyRe.test(line) && i + 1 < headerBlock.length) {
-                    const merged = `${line} ${headerBlock[i + 1]}`.replace(/\s+/g, ' ');
-                    if (keyRe.test(merged)) {
-                        headerCandidates.push(merged);
-                        i++;
-                        continue;
-                    }
+            const seenCandidates = new Set();
+            const candidates = [];
+            const candidateBonuses = new Map();
+
+            function addCandidate(raw, bonus = 0) {
+                if (!raw) return;
+                const normalized = raw.replace(/\s+/g, ' ').trim();
+                if (!normalized) return;
+                const key = normalized.toLowerCase();
+                if (!seenCandidates.has(key)) {
+                    seenCandidates.add(key);
+                    candidates.push(normalized);
                 }
-                if (keyRe.test(line)) {
-                    headerCandidates.push(line.replace(/\s+/g, ' '));
+                if (bonus) {
+                    const current = candidateBonuses.get(normalized) || 0;
+                    if (bonus > current) candidateBonuses.set(normalized, bonus);
                 }
             }
-            if (headerCandidates.length) {
-                const niceName = titleCaseInstitution(headerCandidates[0]);
-                return { code: '', niceName, num };
+
+            function isNameStarter(line) {
+                if (!line) return false;
+                if (/^INFORMATIVO/i.test(line)) return false;
+                if (!/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(line)) return false;
+                const words = line.split(/\s+/).filter(Boolean);
+                if (!words.length) return false;
+                if (keyRe.test(line)) return true;
+                const letterWords = words.filter(w => /[A-Za-zÀ-ÖØ-öø-ÿ]/.test(w));
+                if (!letterWords.length) return false;
+                const uppercaseWords = letterWords.filter(w => w === w.toUpperCase());
+                const uppercaseRatio = uppercaseWords.length / letterWords.length;
+                return uppercaseRatio >= 0.6 && line.length >= 5;
+            }
+
+            function isNameContinuation(line) {
+                if (!line) return false;
+                if (/^INFORMATIVO/i.test(line)) return false;
+                if (/N\.º/i.test(line)) return false;
+                if (!/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(line)) return false;
+                const words = line.split(/\s+/).filter(Boolean);
+                if (!words.length) return false;
+                if (keyRe.test(line)) return true;
+                const letterWords = words.filter(w => /[A-Za-zÀ-ÖØ-öø-ÿ]/.test(w));
+                if (!letterWords.length) return false;
+                const uppercaseWords = letterWords.filter(w => w === w.toUpperCase());
+                const uppercaseRatio = uppercaseWords.length / letterWords.length;
+                if (uppercaseRatio >= 0.5) return true;
+                return letterWords.every(w => lowerCaseWords.has(w.toLowerCase()));
+            }
+
+            // 3) Procura nas primeiras linhas por um nome completo, unindo blocos consecutivos
+            for (let i = 0; i < headerBlock.length; i++) {
+                const line = headerBlock[i];
+                if (!isNameStarter(line)) continue;
+                const group = [line];
+                let j = i + 1;
+                while (j < headerBlock.length && isNameContinuation(headerBlock[j])) {
+                    group.push(headerBlock[j]);
+                    j++;
+                }
+                addCandidate(group.join(' '), 2);
+                i = j - 1;
             }
 
             // Junta linhas quebradas curtas que pertencem à mesma frase institucional
@@ -686,9 +727,11 @@
                 merged.push(L);
             }
 
-            const candidates = merged
-                .filter(l => keyRe.test(l) && l.length >= 20)
-                .map(l => l.replace(/\s+/g, ' '));
+            for (const L of merged) {
+                if (keyRe.test(L) && L.length >= 20) {
+                    addCandidate(L);
+                }
+            }
 
             // 3.1 Heurística especial IF (pega IF + região)
             let ifCandidate = merged.find(l => /INSTITUTO FEDERAL/i.test(l));
@@ -718,6 +761,7 @@
                 if (/FACULDADE|FACULDADES/i.test(c)) score += 2;
                 if (/PONTIF[IÍ]CIA/i.test(c)) score += 1;
                 score += Math.min(c.length / 20, 5);
+                score += candidateBonuses.get(c) || 0;
                 if (score > bestScore) { bestScore = score; best = c; }
             }
 

--- a/informativos-builder.html
+++ b/informativos-builder.html
@@ -602,6 +602,29 @@
             return out;
         }
 
+        const lowerCaseWords = new Set(['de', 'da', 'do', 'das', 'dos', 'e', 'em', 'para', 'por', 'per', 'del', 'della', 'du', 'des', 'di']);
+
+        function titleCaseInstitution(name) {
+            if (!name) return '';
+            const lower = name.toLowerCase();
+            return lower.replace(/[A-Za-zÀ-ÖØ-öø-ÿ]+/g, (match, offset, fullStr) => {
+                const original = name.slice(offset, offset + match.length);
+                if (original === original.toUpperCase() && original.length <= 4 && original.length > 1) {
+                    return original;
+                }
+                if (offset !== 0) {
+                    const prevChar = fullStr[offset - 1];
+                    if (prevChar && /[\-\/]/.test(prevChar)) {
+                        return match.charAt(0).toUpperCase() + match.slice(1);
+                    }
+                }
+                if (offset !== 0 && lowerCaseWords.has(match)) {
+                    return match;
+                }
+                return match.charAt(0).toUpperCase() + match.slice(1);
+            });
+        }
+
         function parseInstitutionInfo(fullText) {
             const text = String(fullText || '').replace(/\u00A0/g, ' ').trim();
 
@@ -609,17 +632,48 @@
             const numMatch = text.match(/N\.º\s*(\d{1,4})/i);
             const num = numMatch ? numMatch[1] : '';
 
+            const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+
+            // bloco inicial até a linha do número
+            const headerBlock = [];
+            for (const line of lines) {
+                if (/N\.º\s*\d{1,4}/i.test(line)) break;
+                headerBlock.push(line);
+                if (headerBlock.length >= 12) break;
+            }
+
+            const keyRe = /^(UNIVERSIDADE|INSTITUTO|CENTRO UNIVERSIT[ÁA]RIO|FACULDADE|PONTIF[IÍ]CIA|ESCOLA|FUNDA[ÇC][ÃA]O|FACULDADES)\b/i;
+
             // 2) Tentativa direta de cabeçalho: "CODE – NOME / 20xx"
             const headerRegex = /^([A-Z0-9 .\/-]+?)\s+[–-]\s+(.+?)\/\s*20\d{2}/m;
             const h = text.match(headerRegex);
             if (h) {
                 let code = (h[1] || '').trim().replace(/\s+/g, ' ');
-                let niceName = (h[2] || '').trim().replace(/\s+/g, ' ');
+                let niceName = titleCaseInstitution((h[2] || '').trim().replace(/\s+/g, ' '));
                 return { code, niceName, num };
             }
 
-            // 3) Fallback: coletar candidatas institucionais (linhas em CAPS com palavras-chave)
-            const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+            // 3) Procura nas primeiras linhas por um nome completo
+            const headerCandidates = [];
+            for (let i = 0; i < headerBlock.length; i++) {
+                let line = headerBlock[i];
+                if (/^INFORMATIVO/i.test(line)) continue;
+                if (!keyRe.test(line) && i + 1 < headerBlock.length) {
+                    const merged = `${line} ${headerBlock[i + 1]}`.replace(/\s+/g, ' ');
+                    if (keyRe.test(merged)) {
+                        headerCandidates.push(merged);
+                        i++;
+                        continue;
+                    }
+                }
+                if (keyRe.test(line)) {
+                    headerCandidates.push(line.replace(/\s+/g, ' '));
+                }
+            }
+            if (headerCandidates.length) {
+                const niceName = titleCaseInstitution(headerCandidates[0]);
+                return { code: '', niceName, num };
+            }
 
             // Junta linhas quebradas curtas que pertencem à mesma frase institucional
             const merged = [];
@@ -632,29 +686,25 @@
                 merged.push(L);
             }
 
-            const keyRe = /^(UNIVERSIDADE|INSTITUTO|CENTRO UNIVERSIT[ÁA]RIO|FACULDADE|PONTIF[IÍ]CIA|ESCOLA|FUNDA[ÇC][ÃA]O|FACULDADES)\b/i;
             const candidates = merged
-                .filter(l => keyRe.test(l) && l.length >= 20) // evita linhas curtas
+                .filter(l => keyRe.test(l) && l.length >= 20)
                 .map(l => l.replace(/\s+/g, ' '));
 
             // 3.1 Heurística especial IF (pega IF + região)
             let ifCandidate = merged.find(l => /INSTITUTO FEDERAL/i.test(l));
             if (!ifCandidate) {
-                // às vezes vem quebrado em duas linhas; tenta concatenar
                 for (let i = 0; i < merged.length - 1; i++) {
                     const duo = (merged[i] + ' ' + merged[i + 1]).replace(/\s+/g, ' ');
                     if (/INSTITUTO FEDERAL/i.test(duo)) { ifCandidate = duo; break; }
                 }
             }
             if (ifCandidate) {
-                // tenta achar a região (ex.: TRIÂNGULO MINEIRO)
                 const regionMatch = ifCandidate.match(/TRI[ÂA]NGULO MINEIRO|SUL DE MINAS|NORTE DE MINAS|SUDESTE DE MINAS|DE MINAS|DE GOI[ÁA]S|DE S[ÃA]O PAULO|DO AMAZONAS|DO PAR[ÁA]/i);
                 let region = regionMatch ? regionMatch[0] : '';
-                // nome canônico do IF (completa a parte de Educação, Ciência e Tecnologia)
                 const niceNameIF = region
                     ? `Instituto Federal de Educação, Ciência e Tecnologia do ${region.replace(/^DE |DO /i, '')}`
                     : `Instituto Federal de Educação, Ciência e Tecnologia`;
-                return { code: '', niceName: niceNameIF, num };
+                return { code: '', niceName: titleCaseInstitution(niceNameIF), num };
             }
 
             // 3.2 Scoring simples para escolher a melhor candidata
@@ -667,17 +717,14 @@
                 if (/CENTRO UNIVERSIT[ÁA]RIO/i.test(c)) score += 3;
                 if (/FACULDADE|FACULDADES/i.test(c)) score += 2;
                 if (/PONTIF[IÍ]CIA/i.test(c)) score += 1;
-                // favorece linhas mais longas (até um limite)
                 score += Math.min(c.length / 20, 5);
                 if (score > bestScore) { bestScore = score; best = c; }
             }
 
-            // Se achou candidata, devolve; o "code" será resolvido por fallback (nome do arquivo)
             if (best) {
-                return { code: '', niceName: best, num };
+                return { code: '', niceName: titleCaseInstitution(best), num };
             }
 
-            // 4) Sem sucesso: devolve só o número; code/niceName serão preenchidos por fallback externo
             return { code: '', niceName: '', num };
         }
 
@@ -687,43 +734,44 @@
 
             let extracted = { code: '', niceName: '', num: '' };
             try {
-            const fullText = await extractTextWithPDFjs(file);
-            extracted = parseInstitutionInfo(fullText);
+                const fullText = await extractTextWithPDFjs(file);
+                extracted = parseInstitutionInfo(fullText);
             } catch (e) {
-            console.warn('Falha na extração com PDF.js:', e);
+                console.warn('Falha na extração com PDF.js:', e);
             }
 
             // fallback nº pelo nome (CODIGO.NUM.pdf)
             if (!extracted.num) {
-            const base = file.name.replace(/\.pdf$/i, '');
-            const m = base.match(/^(.*)\.(\d{1,4})$/);
-            if (m) extracted.num = m[2];
+                const base = file.name.replace(/\.pdf$/i, '');
+                const m = base.match(/^(.*)\.(\d{1,4})$/);
+                if (m) extracted.num = m[2];
             }
 
             // code: preferir o do PDF; senão, usar parte antes do ponto
             let code = extracted.code;
             if (!code) {
-            const base = file.name.replace(/\.pdf$/i, '');
-            const m = base.match(/^(.*)\.(\d{1,4})$/);
-            code = m ? m[1] : base;
+                const base = file.name.replace(/\.pdf$/i, '');
+                const m = base.match(/^(.*)\.(\d{1,4})$/);
+                code = m ? m[1] : base;
             }
             code = code.replace(/\s+/g, ' ').replace(/\s-\s/g, ' - ').trim();
 
-            // niceName extraído; se vazio, mantém editável (ou usa dict se quiser fallback)
+            // niceName extraído do PDF; se vazio, tenta fallback opcional do dicionário manual
             let niceName = extracted.niceName || '';
+            niceName = titleCaseInstitution(niceName);
             if (!niceName && dict && dict[code]) {
-            niceName = dict[code];
+                niceName = titleCaseInstitution(dict[code]);
             }
 
             console.log({ code, num: extracted.num, niceName });
 
             return {
-            file,
-            code,
-            num: extracted.num || '',
-            niceName,
-            niceNameMissing: !niceName,
-            ok: false
+                file,
+                code,
+                num: extracted.num || '',
+                niceName,
+                niceNameMissing: !niceName,
+                ok: false
             };
         }
 


### PR DESCRIPTION
## Summary
- detect institution names directly from the PDF content, focusing on header lines before the “N.º” marker
- normalize detected names into title case while keeping common prepositions lowercase and preserving short acronyms
- retain the optional manual dictionary as a fallback and apply the same casing rules to its entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee6f4f8ec4832696718d480c0a506f